### PR TITLE
chore: separate view for magic link vs. password sign in.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ For example, you can create business models with different pricing tiers, e.g.:
   - [...]: additional currency and interval combinations
 - Product 2: Freelancer
   - Price 1: 20 USD per month
-  - Price 2: 20 USD per year
+  - Price 2: 200 USD per year
   - Price 3: 16 GBP per month
   - Price 4: 160 GBP per year
   - [...]: additional currency and interval combinations

--- a/pages/signin.js
+++ b/pages/signin.js
@@ -83,7 +83,7 @@ const SignIn = () => {
                 variant="slim"
                 type={!password.length ? 'submit' : 'button'}
                 loading={!password.length && loading}
-                disabled={!email.length || !!password.length}
+                disabled={!email.length}
                 onClick={handleSignin}
               >
                 Send magic link
@@ -113,18 +113,21 @@ const SignIn = () => {
             </div>
 
             <span className="pt-1 text-center text-sm">
-              <span
+              <a
+                href="#"
                 className="text-accents-7 text-accent-9 hover:underline cursor-pointer"
                 onClick={() => {
                   if (showPasswordInput) setPassword('');
-                  setShowPasswordInput(!showPasswordInput);
+                  setShowPasswordInput(!showPasswordInput && !password.length);
                   setMessage('');
                 }}
               >
                 {`Or sign in with ${
-                  showPasswordInput ? 'magic link' : 'password'
+                  showPasswordInput || !!password.length
+                    ? 'magic link'
+                    : 'password'
                 }.`}
-              </span>
+              </a>
             </span>
 
             <span className="pt-1 text-center text-sm">

--- a/pages/signin.js
+++ b/pages/signin.js
@@ -57,9 +57,11 @@ const SignIn = () => {
           <div className="flex flex-col space-y-4">
             {message && (
               <div
-                className={`text-${
-                  password.length ? 'pink' : 'green'
-                } border border-${password.length ? 'pink' : 'green'} p-3`}
+                className={`${
+                  password.length ? 'text-pink' : 'text-green'
+                } border ${
+                  password.length ? 'border-pink' : 'border-green'
+                } p-3`}
               >
                 {message}
               </div>

--- a/pages/signin.js
+++ b/pages/signin.js
@@ -17,7 +17,7 @@ const SignIn = () => {
   const { user, signIn } = useUser();
 
   const handleSignin = async (e) => {
-    e.preventDefault();
+    if (e.preventDefault) e.preventDefault();
 
     setLoading(true);
     setMessage('');
@@ -70,23 +70,36 @@ const SignIn = () => {
               onChange={setEmail}
               required
             />
+            <Button
+              variant="slim"
+              type={!password.length ? 'submit' : 'button'}
+              loading={!password.length && loading}
+              disabled={!email.length || !!password.length}
+              onClick={handleSignin}
+            >
+              Send magic link
+            </Button>
             <Input
               type="password"
               placeholder="Password"
               onChange={setPassword}
             />
-            <div className="pt-2 w-full flex flex-col">
-              <Button variant="slim" type="submit" loading={loading}>
-                {password.length ? 'Sign In' : 'Send Magic Link'}
-              </Button>
-            </div>
+            <Button
+              className="mt-1"
+              variant="slim"
+              type={password.length ? 'submit' : 'button'}
+              loading={!!password.length && loading}
+              disabled={!password.length}
+            >
+              Sign in
+            </Button>
 
             <span className="pt-1 text-center text-sm">
               <span className="text-accents-7">Don't have an account?</span>
               {` `}
               <Link href="/signup">
                 <a className="text-accent-9 font-bold hover:underline cursor-pointer">
-                  Sign Up
+                  Sign up.
                 </a>
               </Link>
             </span>

--- a/pages/signin.js
+++ b/pages/signin.js
@@ -11,6 +11,7 @@ import GitHub from '../components/icons/GitHub';
 const SignIn = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [showPasswordInput, setShowPasswordInput] = useState(false);
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState('');
   const router = useRouter();
@@ -72,29 +73,53 @@ const SignIn = () => {
               onChange={setEmail}
               required
             />
-            <Button
-              variant="slim"
-              type={!password.length ? 'submit' : 'button'}
-              loading={!password.length && loading}
-              disabled={!email.length || !!password.length}
-              onClick={handleSignin}
+            <div
+              className={`w-full flex flex-col ${
+                showPasswordInput ? 'hidden' : ''
+              }`}
             >
-              Send magic link
-            </Button>
-            <Input
-              type="password"
-              placeholder="Password"
-              onChange={setPassword}
-            />
-            <Button
-              className="mt-1"
-              variant="slim"
-              type={password.length ? 'submit' : 'button'}
-              loading={!!password.length && loading}
-              disabled={!password.length}
+              <Button
+                variant="slim"
+                type={!password.length ? 'submit' : 'button'}
+                loading={!password.length && loading}
+                disabled={!email.length || !!password.length}
+                onClick={handleSignin}
+              >
+                Send magic link
+              </Button>
+            </div>
+
+            <div
+              className={`flex flex-col space-y-4 ${
+                !showPasswordInput ? 'hidden' : ''
+              }`}
             >
-              Sign in
-            </Button>
+              <Input
+                type="password"
+                placeholder="Password"
+                onChange={setPassword}
+              />
+              <Button
+                className="mt-1"
+                variant="slim"
+                type={password.length ? 'submit' : 'button'}
+                loading={!!password.length && loading}
+                disabled={!password.length}
+              >
+                Sign in
+              </Button>
+            </div>
+
+            <span className="pt-1 text-center text-sm">
+              <span
+                className="text-accents-7 text-accent-9 hover:underline cursor-pointer"
+                onClick={() => setShowPasswordInput(!showPasswordInput)}
+              >
+                {`Or sign in with ${
+                  showPasswordInput ? 'magic link' : 'password'
+                }.`}
+              </span>
+            </span>
 
             <span className="pt-1 text-center text-sm">
               <span className="text-accents-7">Don't have an account?</span>

--- a/pages/signin.js
+++ b/pages/signin.js
@@ -57,9 +57,9 @@ const SignIn = () => {
           <div className="flex flex-col space-y-4">
             {message && (
               <div
-                className={`text-${password ? 'pink' : 'green'} border border-${
-                  password ? 'pink' : 'green'
-                } p-3`}
+                className={`text-${
+                  password.length ? 'pink' : 'green'
+                } border border-${password.length ? 'pink' : 'green'} p-3`}
               >
                 {message}
               </div>

--- a/pages/signin.js
+++ b/pages/signin.js
@@ -70,12 +70,13 @@ const SignIn = () => {
             <Input
               type="email"
               placeholder="Email"
+              value={email}
               onChange={setEmail}
               required
             />
             <div
               className={`w-full flex flex-col ${
-                showPasswordInput ? 'hidden' : ''
+                showPasswordInput || password.length ? 'hidden' : ''
               }`}
             >
               <Button
@@ -91,12 +92,13 @@ const SignIn = () => {
 
             <div
               className={`flex flex-col space-y-4 ${
-                !showPasswordInput ? 'hidden' : ''
+                showPasswordInput || password.length ? '' : 'hidden'
               }`}
             >
               <Input
                 type="password"
                 placeholder="Password"
+                value={password}
                 onChange={setPassword}
               />
               <Button
@@ -113,7 +115,11 @@ const SignIn = () => {
             <span className="pt-1 text-center text-sm">
               <span
                 className="text-accents-7 text-accent-9 hover:underline cursor-pointer"
-                onClick={() => setShowPasswordInput(!showPasswordInput)}
+                onClick={() => {
+                  if (showPasswordInput) setPassword('');
+                  setShowPasswordInput(!showPasswordInput);
+                  setMessage('');
+                }}
               >
                 {`Or sign in with ${
                   showPasswordInput ? 'magic link' : 'password'

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -71,7 +71,7 @@ const SignUp = () => {
             loading={loading}
             disabled={loading}
           >
-            Sign Up
+            Sign up
           </Button>
         </div>
 
@@ -80,7 +80,7 @@ const SignUp = () => {
           {` `}
           <Link href="/signin">
             <a className="text-accent-9 font-bold hover:underline cursor-pointer">
-              Sign In
+              Sign in.
             </a>
           </Link>
         </span>


### PR DESCRIPTION
As we've gotten feedback that the button changing its title is confusing, change to two different views:

- Default view: 
![image](https://user-images.githubusercontent.com/5748289/101331538-1d7b8a80-38af-11eb-9904-3fcec3c83fd4.png)

- Sign in with password view:
![image](https://user-images.githubusercontent.com/5748289/101333572-bad7be00-38b1-11eb-88cc-e54a68408873.png)
